### PR TITLE
feat: centralised docker env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
-# Use Amazon Corretto's OpenJDK 17 base image for ARM64 architecture
-FROM amazoncorretto:17-alpine
-
-# Set the working directory
+# Use a Maven image for building the application
+FROM maven:3.9.4-eclipse-temurin-17 AS builder
 WORKDIR /app
 
-# Copy the built JAR file into the container
-COPY target/demo-0.0.1-SNAPSHOT.jar app.jar
+# Copy the source code
+COPY . .
 
-# Expose ports for the application and remote debugging
-EXPOSE 8080 5005
+# Build the project
+RUN mvn clean package -DskipTests
 
-# Run the application with remote debugging options
+# Use a lightweight JRE image for running the application
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+
+# Copy the .jar file from the builder stage
+COPY --from=builder /app/target/demo-0.0.1-SNAPSHOT.jar app.jar
+
+# Run the application
 ENTRYPOINT ["java", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005", "-jar", "app.jar"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,5 +6,4 @@ WORKDIR /app
 COPY . .
 
 # Run the tests
-CMD ["mvn", "test", "-Dmaven.surefire.debug"]
-
+CMD ["mvn", "test", "-Dmaven.surefire.debug", "-DargLine=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,10 @@
+# Use a Maven image for running tests
+FROM maven:3.9.4-eclipse-temurin-17 AS test-runner
+WORKDIR /app
+
+# Copy the source code
+COPY . .
+
+# Run the tests
+CMD ["mvn", "test", "-Dmaven.surefire.debug"]
+

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,3 @@
-# Use a Maven image for running tests
 FROM maven:3.9.4-eclipse-temurin-17 AS test-runner
 WORKDIR /app
 
@@ -6,4 +5,4 @@ WORKDIR /app
 COPY . .
 
 # Run the tests
-CMD ["mvn", "test", "-Dmaven.surefire.debug", "-DargLine=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005"]
+CMD ["mvn", "test"]

--- a/README.md
+++ b/README.md
@@ -40,9 +40,8 @@ _spring.application.name_
 #### Docker Approach Mac ARM (M1, M2, M3, M4):
         * brew install docker 
         * brew install colima (because you're not a wanker to use GUI)
-        * docker-compose up --build (This will create the Mongo Image) or
-        * mvn clean package (to make sure youre using the last build)
-        * docker build -t alletemp .
+        * docker-compose up --build (This will create the Mongo Image and test container) or
+        * docker build -t alletemp . (for the api only)
         * docker run -p 8080:8080 -p 5005:5005 alletemp
 Make sure you have 5005:5005 otherwise debugging will not work
 Configuring the Debugger in IntelliJ
@@ -54,7 +53,17 @@ Configuring the Debugger in IntelliJ
             * Save
             * Add Breakpoints and test
 
-#### Manual Approach
+#### Running tests
+
+Tests were moved to docker, so we have a container that is focused on our unit tests
+
+            * Run one test: mvn test -Dtest=YourTestClassName
+            * Run one single method: mvn test -Dtest=YourTestClassName#yourMethodName
+            * Attach the debugger: docker-compose run --rm test-runner mvn test -Dmaven.surefire.debug -Dtest=YourTestClassName#yourMethodName
+            * Cleanup environment: docker-compose down --volumes --remove-orphans docker system prune -a
+            * Later: docker system prune -a
+
+#### Manual Approach (DEPRECATED)
         * mvn clean install
         * java -jar target/demo-0.0.1-SNAPSHOT.jar
         * Or use IntelliJ

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,11 @@ services:
       context: .
       dockerfile: Dockerfile.test
     container_name: spring-boot-tests
+    ports:
+      - "5006:5005"
     depends_on:
       - mongodb
     environment:
       - SPRING_DATA_MONGODB_URI=mongodb://mongodb:27017/mydatabase
-
 volumes:
   mongo-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,15 @@ services:
     depends_on:
       - mongodb
 
-#  test-runner:
-#    build:
-#      context: .
-#      dockerfile: Dockerfile.test
-#    container_name: spring-boot-tests
-#    depends_on:
-#      - mongodb
+  test-runner:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    container_name: spring-boot-tests
+    depends_on:
+      - mongodb
+    environment:
+      - SPRING_DATA_MONGODB_URI=mongodb://mongodb:27017/mydatabase
 
 volumes:
   mongo-data:

--- a/src/main/java/com/allesys/demo/controller/DayController.java
+++ b/src/main/java/com/allesys/demo/controller/DayController.java
@@ -28,8 +28,13 @@ public class DayController {
     }
 
     @GetMapping("/{id}")
-    public Optional<Day> getDayById(@PathVariable String id) {
-        return dayService.getDayById(id);
+    public ResponseEntity<Day> getDayById(@PathVariable String id) {
+        Optional<Day> day = dayService.getDayById(id);
+        if (day.isPresent()) {
+            return ResponseEntity.ok(day.get());
+        } else {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
     }
 
     @GetMapping("/current")


### PR DESCRIPTION
No more `mvn clean install` locally and I'm moving the tests to docker. So docker will deal with the entire environment. This was made because I was having too much issues with aarch64 and Linux. Machine Learning worked fine on x86, but not well on the aarch64. Since my server runs on aarch64 the best decision was to move the entire environment to docker. 